### PR TITLE
fix: fixed typo in cloudtrail key policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ data "aws_iam_policy_document" "cloudtrail_key_policy" {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
       values = [
-        "arn:aws:cloudtrail:us-east-1:156873913342:trail/<trail_Name>"
+        "arn:aws:cloudtrail:us-east-1:156873913342:trail/*"
       ]
     }
   }


### PR DESCRIPTION
## what
* Fixed Typo in the cloudtrail key policy

## why
* Was having issue while creating cloudtrail and was not able to manager cloudtrail using terarform in projects.