### PR TITLE
feature/optional-modules-toggle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "labels" {
 #               type specific features.
 
 module "s3_log_bucket" {
+  count  = var.s3_log_bucket ? 1 : 0
   source = "git::https://github.com/clouddrove/terraform-aws-s3.git?ref=tags/2.0.0"
 
   name        = var.s3_log_bucket_name
@@ -33,6 +34,7 @@ module "s3_log_bucket" {
 }
 
 module "s3_bucket" {
+  count   = var.s3_bucket ? 1 : 0
   source  = "clouddrove/s3/aws"
   version = "2.0.0"
 
@@ -334,6 +336,7 @@ module "cloudtrail" {
 }
 
 module "cloudtrail-slack-notification" {
+  count  = var.cloudtrail-slack-notification ? 1 : 0
   source = "git::https://github.com/clouddrove/terraform-aws-cloudtrail-slack-notification.git?ref=tags/1.0.1"
 
   name        = "cloudtrail-slack-notification"

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,21 @@ variable "sse_algorithm" {
   description = "The server-side encryption algorithm to use. Valid values are AES256 and aws:kms."
 }
 
+variable "cloudtrail-slack-notification" {
+  type        = bool
+  default     = true
+  description = "Enable CloudTrail Slack Notification."
+}
+
+variable "s3_bucket" {
+  type        = bool
+  default     = true
+  description = "enable s3 bucket"
+}
+
+variable "s3_log_bucket" {
+  type        = bool
+  default     = true
+  description = "enable s3 log bucket"
+}
+


### PR DESCRIPTION
## what
* Introduced a feature count mechanism to allow users to optionally enable or disable the following modules:
  * `s3_bucket`
  * `s3_log_bucket`
  * `CloudTrail-slack-notification`

## why
* Provides users with more control over which modules are deployed, improving modularity and customization.
* Reduces unnecessary resource provisioning for users who do not require these specific modules.